### PR TITLE
Fixed array reference.

### DIFF
--- a/src/SourceGeneration.Reflection.SourceGenerator/ReflectionSourceGenerator.Emit.cs
+++ b/src/SourceGeneration.Reflection.SourceGenerator/ReflectionSourceGenerator.Emit.cs
@@ -174,8 +174,14 @@ public partial class ReflectionSourceGenerator
             {
                 if (field.IsConst)
                 {
-                    builder.AppendLine($@"GetValue = static _ => {CSharpCodeBuilder.GetConstantLiteral(field.ConstantValue)},");
-                }
+					builder.Append("GetValue = static _ => ");
+					builder.AppendLine(
+						type.IsEnum
+							// Use enum value
+							? $"{type.FullGlobalName}.{field.Name},"
+							: $"{CSharpCodeBuilder.GetConstantLiteral(field.ConstantValue)},"
+					);
+				}
                 else if (field.IsStatic)
                 {
                     builder.AppendLine($@"GetValue = static instance => {type.FullGlobalName}.{field.Name},");
@@ -464,9 +470,9 @@ public partial class ReflectionSourceGenerator
     {
         if (parameters.Count == 0)
         {
-            builder.AppendLine($"{propertyName} = Array.Empty<global::SourceGeneration.Reflection.SourceParameterInfo>(),");
-        }
-        else
+			builder.AppendLine($"{propertyName} = global::System.Array.Empty<global::SourceGeneration.Reflection.SourceParameterInfo>(),");
+		}
+		else
         {
             builder.AppendBlock($"{propertyName} = new global::SourceGeneration.Reflection.SourceParameterInfo[]", () =>
             {

--- a/src/SourceGeneration.Reflection.Test/EnumTest.cs
+++ b/src/SourceGeneration.Reflection.Test/EnumTest.cs
@@ -14,13 +14,14 @@ public class EnumTest
         Assert.AreEqual("A", type.DeclaredFields[0].Name);
         Assert.AreEqual("B", type.DeclaredFields[1].Name);
 
-        Assert.AreEqual(0, type.DeclaredFields[0].GetValue(null));
-        Assert.AreEqual(1, type.DeclaredFields[1].GetValue(null));
+        Assert.AreEqual(EnumTestObject.A, type.DeclaredFields[0].GetValue(null));
+        Assert.AreEqual(EnumTestObject.B, type.DeclaredFields[1].GetValue(null));
     }
 }
 
 [SourceReflection]
 public enum EnumTestObject
 {
-    A,B,
+    A = 21,
+    B = 49,
 }


### PR DESCRIPTION
Update Enum GetValue to use the enum reference rather than number value.

I tried to write a test for the Array reference fix but I could not get it to fail in your project but my fork (in another solution) always failed.

I also have many other updates like access to DisplayAttribute values but I'm not sure if you would want those changes.

Edit: sorry for the tabs, if you want I can fix those, or if you're like me you'll edit the changes anyway.